### PR TITLE
Update to discordgo 0.23.1

### DIFF
--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -43,7 +43,7 @@ func main() {
 	Mgr.AddHandler(onConnect)
 
 	// In this example, we only care about receiving message events.
-	Mgr.RegisterIntent(discordgo.MakeIntent(discordgo.IntentsGuildMessages))
+	Mgr.RegisterIntent(discordgo.IntentsGuildMessages)
 
 	fmt.Println("[INFO] Starting shard manager...")
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/servusdei2018/shards
 
 go 1.15
 
-require github.com/bwmarrin/discordgo v0.22.1
+require github.com/bwmarrin/discordgo v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bwmarrin/discordgo v0.22.1 h1:254fNYyfqJWKbPzO5g8j/nUvRgj4dNlI19EB8rnkpt8=
-github.com/bwmarrin/discordgo v0.22.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
+github.com/bwmarrin/discordgo v0.23.1 h1:xlK4/69bpl/VSoCYaKe3BOc9j1HkNopoRdCppRYu8dk=
+github.com/bwmarrin/discordgo v0.23.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=

--- a/manager.go
+++ b/manager.go
@@ -13,7 +13,7 @@ type Manager struct {
 	// Discord gateway.
 	Gateway *discordgo.Session
 	// Discord intent.
-	Intent *discordgo.Intent
+	Intent discordgo.Intent
 	// Shards managed by this Manager.
 	Shards []*Shard
 	// Total Shard count.
@@ -81,7 +81,7 @@ func New(token string) (mgr *Manager, err error) {
 }
 
 // RegisterIntent sets the Intent for all Shards' sessions.
-func (m *Manager) RegisterIntent(intent *discordgo.Intent) {
+func (m *Manager) RegisterIntent(intent discordgo.Intent) {
 	m.Lock()
 	defer m.Unlock()
 	m.Intent = intent

--- a/shards.go
+++ b/shards.go
@@ -55,7 +55,7 @@ func (s *Shard) GuildCount() (count int) {
 
 // Init initializes a shard with a bot token, its Shard ID, the total
 // amount of shards, and a Discord intent.
-func (s *Shard) Init(token string, ID, ShardCount int, intent *discordgo.Intent) (err error) {
+func (s *Shard) Init(token string, ID, ShardCount int, intent discordgo.Intent) (err error) {
 	s.Lock()
 	defer s.Unlock()
 


### PR DESCRIPTION
In discordgo 0.23.0, Intents were made mandatory and the type changed from `*discordgo.Intent` to `discordgo.Intent`

p.s. you don't have a dev branch to make a request to.