### PR TITLE
fix: sharding improperly applied to sessions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/bwmarrin/discordgo v0.23.1 h1:xlK4/69bpl/VSoCYaKe3BOc9j1HkNopoRdCppRYu8dk=
-github.com/bwmarrin/discordgo v0.23.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/bwmarrin/discordgo v0.23.3-0.20210410202908-577e7dd4f6cc h1:S3C2Q9BUNkjWFO5S5FVghkIHZ/g+PmYYr/+luZ83FVc=
 github.com/bwmarrin/discordgo v0.23.3-0.20210410202908-577e7dd4f6cc/go.mod h1:OMKxbTmkKofBjBi4/yidO3ItxbJ6PUfEUkjchM4En8c=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=

--- a/manager.go
+++ b/manager.go
@@ -181,6 +181,7 @@ func (m *Manager) Start() (err error) {
 	}
 
 	// Initialize Shards.
+	m.Shards = []*Shard{}
 	for i := 0; i < m.ShardCount; i++ {
 		m.Shards = append(m.Shards, &Shard{})
 	}

--- a/shards.go
+++ b/shards.go
@@ -51,7 +51,7 @@ func (s *Shard) ApplicationCommandCreate(guildID string, cmd *discordgo.Applicat
 	if s.Session == nil {
 		return fmt.Errorf("error: shard.ApplicationCommandCreate must not be called before shard.Init")
 	}
-	
+
 	_, err := s.Session.ApplicationCommandCreate(s.Session.State.User.ID, guildID, cmd)
 	return err
 }

--- a/shards.go
+++ b/shards.go
@@ -86,6 +86,10 @@ func (s *Shard) Init(token string, ID, ShardCount int, intent discordgo.Intent) 
 		return
 	}
 
+	// Shard the session.
+	s.Session.ShardCount = s.ShardCount
+	s.Session.ShardID = s.ID
+
 	// Identify our intent.
 	s.Session.Identify.Intents = intent
 


### PR DESCRIPTION
Properly applied sharding configuration to shards #5 , and added a safeguard in `manager.go` that ensures that `Start()` always begins with an empty slice of `Shard`s.