### PR TITLE
Apply events to session after shard init

### DIFF
--- a/shards.go
+++ b/shards.go
@@ -12,7 +12,7 @@ const (
 	// TIMELIMIT specifies how long to pause between connecting shards.
 	TIMELIMIT = time.Second * 5
 	// VERSION specifies the shards module version. Follows semantic versioning (semver.org).
-	VERSION = "2.6.2"
+	VERSION = "2.6.3"
 )
 
 // A Shard represents a shard.
@@ -32,23 +32,29 @@ type Shard struct {
 }
 
 // AddHandler registers an event handler for a Shard.
-//
-// Shouldn't be called after Init or results in undefined behavior.
 func (s *Shard) AddHandler(handler interface{}) {
 	s.Lock()
 	defer s.Unlock()
 
 	s.handlers = append(s.handlers, handler)
+
+	// Add the handler to the session.
+	if s.Session != nil {
+		s.Session.AddHandler(handler)
+	}
 }
 
 // AddHandlerOnce registers an event handler for a Shard that will only be called once.
-//
-// Shouldn't be called after Init or results in undefined behavior.
 func (s *Shard) AddHandlerOnce(handler interface{}) {
 	s.Lock()
 	defer s.Unlock()
 
 	s.handlersOnce = append(s.handlersOnce, handler)
+
+	// Add the handler to the session.
+	if s.Session != nil {
+		s.Session.AddHandlerOnce(handler)
+	}
 }
 
 // ApplicationCommandCreate registers an application command for a Shard.


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message is straightforward and to the point
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug

* **What is the current behavior?** (You can also link to an open issue here)
Events can only be registered to the shard/manager before init
If events are registered after shard/manager init, they won't actually be registered to the underlying session

* **What is the new behavior (if this is a feature change)?**
Events can be registered to the shard/manager before or after init and will be registered correctly to the session in both circumstances

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A

* **Other information**:
N/A
